### PR TITLE
Add support for Redhat, Centos, Fedora, and Amazon Linux

### DIFF
--- a/templates/default/etc/init.d/pgbouncer.erb
+++ b/templates/default/etc/init.d/pgbouncer.erb
@@ -1,0 +1,150 @@
+#!/bin/sh
+#
+# pgbouncer	Start PgBouncer connection pooler daemon
+#
+# chkconfig: - 64 36
+# description: PgBouncer is a connection pooler for PostgreSQL. \
+#              This service starts the PgBouncer daemon.
+
+## BEGIN INIT INFO
+# Provides: pgbouncer
+# Required-Start: $local_fs $remote_fs $network $syslog $named
+# Required-Stop: $local_fs $remote_fs $network $syslog $named
+# Should-Start: postgresql
+# Short-Description: Start PgBouncer connection pooler daemon
+# Description: PgBouncer is a connection pooler for PostgreSQL.
+#              This service starts the PgBouncer daemon.
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+exec=/usr/bin/pgbouncer
+prog=pgbouncer-<%= @db_alias %>
+pidfile=/var/run/pgbouncer/pgbouncer-<%= @db_alias %>.pid
+lockfile=/var/lock/subsys/$prog
+
+# Get config.
+. /etc/sysconfig/network
+
+# Override defaults from /etc/sysconfig/pgbouncer if file is present
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+# Check that networking is up.
+[ "${NETWORKING}" = "no" ] && exit 6
+
+start(){
+	[ -x $exec ] || exit 5
+	[ -f "$BOUNCERCONF" ] || exit 6
+	echo -n "Starting $prog: "
+
+	# Make sure startup-time log file is valid
+	if [ ! -e "$BOUNCERLOG" -a ! -h "$BOUNCERLOG" ]
+	then
+		touch "$BOUNCERLOG" || exit 1
+		chown pgbouncer:pgbouncer "$BOUNCERLOG"
+		chmod go-rwx "$BOUNCERLOG"
+		[ -x /usr/bin/chcon ] && /usr/bin/chcon -u system_u -r object_r -t postgresql_log_t "$BOUNCERLOG" 2>/dev/null
+	fi
+
+        mkdir -p $(dirname $pidfile)
+	chown pgbouncer:pgbouncer $(dirname $pidfile)
+
+	cd /
+	daemon --user=pgbouncer --pidfile=$pidfile $exec -d -q $BOUNCERCONF
+	retval=$?
+        echo
+	[ $retval -eq 0 ] && touch $lockfile
+	return $retval
+}
+
+stop(){
+	echo -n "Stopping $prog: "
+	killproc -p $pidfile $prog -TERM
+	retval=$?
+	echo
+	[ $retval -eq 0 ] && rm -f $lockfile
+	return $retval
+}
+
+restart(){
+	if rh_status_q; then
+		echo -n "Restarting $prog: "
+		cd /
+		daemon --force --user=pgbouncer --pidfile=$pidfile $exec -R -d -q $BOUNCERCONF
+		retval=$?
+		echo
+		return $retval
+	else
+		start
+	fi
+}
+
+reload(){
+	echo -n "Reloading $prog: "
+	killproc $exec -HUP
+	retval=$?
+	echo
+	return $retval
+}
+
+pause(){
+	echo -n "Pausing $prog: "
+	killproc $exec -USR1
+	retval=$?
+	echo
+	return $retval
+}
+
+resume(){
+	echo -n "Resuming $prog: "
+	killproc $exec -USR2
+	retval=$?
+	echo
+	return $retval
+}
+
+rh_status() {
+	status -p $pidfile $prog
+}
+
+rh_status_q() {
+	rh_status >/dev/null 2>&1
+}
+
+
+case "$1" in
+  start)
+	rh_status_q && exit 0
+	start
+	;;
+  stop)
+	rh_status_q || exit 0
+	stop
+	;;
+  restart)
+	restart
+	;;
+  reload|force-reload)
+	rh_status_q || exit 7
+	reload
+	;;
+  condrestart|try-restart)
+	rh_status_q || exit 0
+	restart
+	;;
+  status)
+	rh_status
+	;;
+  pause)
+	pause
+	;;
+  continue)
+	resume
+	;;
+  *)
+	echo $"Usage: $0 {start|stop|restart|reload|force-reload|condrestart|try-restart|status|pause|continue}"
+	exit 2
+esac
+
+exit $?

--- a/templates/default/etc/sysconfig/pgbouncer.erb
+++ b/templates/default/etc/sysconfig/pgbouncer.erb
@@ -1,0 +1,8 @@
+# pgbouncer defaults
+#
+
+# Path to the init file
+BOUNCERCONF=/etc/pgbouncer/pgbouncer-<%= @db_alias %>.ini
+
+# Path to the log file
+BOUNCERLOG=/var/log/pgbouncer/pgbouncer-<%= @db_alias %>.log


### PR DESCRIPTION
- Fixes typo in teardown step (a template location was incorrect)
- Adds support for Redhat, Centos, Fedora, and Amazon Linux
  - Removes upstart as hard-coded provider. Upstart will by default be used on Ubuntu and Debian. Systemd will by default be used on Redhat, Centos, Fedora, and Amazon Linux.
